### PR TITLE
Speed Comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To test local changes run:
 make test
 ```
 
-# Run
+### Run
 
 To run each algorithm on cartpole swingup from the base directory:
 
@@ -32,7 +32,19 @@ python jax_rl/main_dm_control.py --policy SAC --max_timesteps 100000
 python jax_rl/main_dm_control.py --policy MPO --max_timesteps 100000
 ```
 
-# Results
+## Results
+
+### Speed
+
+As one would hope, the time per training step is significantly faster between JAX and other leading deep learning frameworks. The following comparison is the time in seconds per 1000 training steps with the same hyperparameters. For those interested in hardware, these were all run on the same machine, mid-2019 MacBook Pro 15-inch - 2.3 GHz Intel Core i9 - 16GB RAM.
+
+|     |      JAX     |    PyTorch    |
+|-----|:------------:|:-------------:|
+| TD3 | 2.35 ± 0.17  | 6.93 ± 0.16   |
+| SAC | 5.57 ± 0.07  | 32.37 ± 1.32  |
+| MPO | 39.19 ± 1.09 | 107.51 ± 3.56 |
+
+### Performance
 
 Better benchmarking to come on a wider range of environments and with more seeds. Below is the most simple example to demonstrate that the algorithms converge well on a simple task.
 
@@ -41,6 +53,13 @@ Better benchmarking to come on a wider range of environments and with more seeds
 
 ## Notes on MPO Implementation
 
-Because we have direct access to the jacobian function with JAX, I've opted to use `scipy.optimize.minimize` instead of taking a single gradient step on the temperature parameter per iteration. In my testing this gives much greater stability with only a marginal increase in time per iteration. If your top priority is speed, this can be easily modified.
+Because we have direct access to the jacobian function with JAX, I've opted to use `scipy.optimize.minimize` instead of taking a single gradient step on the temperature parameter per iteration. In my testing this gives much greater stability with only a marginal increase in time per iteration.
 
-One important aspect to note if you are benchmarking these two approaches is that a standard profiler will be misleading. Most of the time will show up in the call to `scipy.optimize.minimize`, but this is due to how JAX calls work internally. JAX does not wait for an operation to complete when an operation is called, but rather returns a pointer to a `DeviceArray` whose value will be updated when the dispatched call is complete. If this object is passed into another JAX method, the same process will be repeated and control will be returned to Python. Any time Python attempts to access the value of a `DeviceArray` it will need to wait for the computation to complete. Because `scipy.optimize.minimize` passed the values of the parameter and the gradient to FORTRAN, this step will require the whole program to wait for all previous JAX calls to complete. To get a more accurate comparison, compare the total time per training step. To readmore about how asyncronous dispatch works in JAX, see [this reference](https://jax.readthedocs.io/en/latest/async_dispatch.html).
+One important aspect to note if you are benchmarking these two approaches is that a standard profiler will be misleading. Most of the time will show up in the call to `scipy.optimize.minimize`, but this is due to how JAX calls work internally. JAX does not wait for an operation to complete when an operation is called, but rather returns a pointer to a `DeviceArray` whose value will be updated when the dispatched call is complete. If this object is passed into another JAX method, the same process will be repeated and control will be returned to Python. Any time Python attempts to access the value of a `DeviceArray` it will need to wait for the computation to complete. Because `scipy.optimize.minimize` passed the values of the parameter and the gradient to FORTRAN, this step will require the whole program to wait for all previous JAX calls to complete. To get a more accurate comparison, compare the total time per training step. To read more about how asynchronous dispatch works in JAX, see [this reference](https://jax.readthedocs.io/en/latest/async_dispatch.html).
+
+I've run a quick comparison of the two following the same procedure as the `Speed` section above.
+
+| Sequential Least Squares | Gradient Descent |
+|:------------------------:|:----------------:|
+|       39.19 ± 1.09       |   38.26 ± 2.74   |
+


### PR DESCRIPTION
Update `README` with time comparison for each algorithm with PyTorch. Show time difference for Sequential Least Squares vs. SGD.